### PR TITLE
Docs: switch coverage badge to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/aop/actions"><img src="https://github.com/contributte/aop/workflows/build/badge.svg"></a>
-  <a href="https://coveralls.io/r/contributte/aop"><img src="https://badgen.net/coveralls/c/github/contributte/aop?cache=300"></a>
+  <a href="https://codecov.io/gh/contributte/aop"><img src="https://badgen.net/codecov/c/github/contributte/aop"></a>
   <a href="https://packagist.org/packages/contributte/aop"><img src="https://badgen.net/packagist/dm/contributte/aop"></a>
   <a href="https://packagist.org/packages/contributte/aop"><img src="https://badgen.net/packagist/v/contributte/aop"></a>
 </p>


### PR DESCRIPTION
## What changed
- replaced the README coverage badge link from Coveralls to Codecov
- confirmed the repository already uses the shared Codecov-ready coverage workflow, so no workflow changes were needed

## Why
- completes the remaining Coveralls-to-Codecov migration work for this repository
- keeps coverage links aligned with the current reporting setup tracked in contributte/contributte#72

Refs: contributte/contributte#72